### PR TITLE
Replaced add() with pl_sum()

### DIFF
--- a/tests/testthat/test-landscape-exact.R
+++ b/tests/testthat/test-landscape-exact.R
@@ -28,7 +28,7 @@ test_that("PL sum is correct for simple case.", {
   pl1 <- pl_new(pd1, exact = TRUE)
   pl2 <- pl_new(pd2, exact = TRUE)
   
-  pl <- pl1$add(pl2)
+  pl <- pl_sum(list(pl1,pl2))
   expected <- list(matrix(c(-Inf, 0, 1, 1.5, 2, Inf, 0, 0, 1, 1, 0, 0),
                           nrow = 6, ncol = 2))
   

--- a/tests/testthat/test-pl-new.R
+++ b/tests/testthat/test-pl-new.R
@@ -1,7 +1,7 @@
 set.seed(120246L)
 t <- runif(12, 0, 2*pi)
 x <- cbind(cos(t), sin(t))
-pd_a <- alphaComplexDiag(x, maxdimension = 1)
+pd_a <- TDA::alphaComplexDiag(x, maxdimension = 1)
 pd_a$diagram[, c(2, 3)] <- sqrt(pd_a$diagram[, c(2, 3)])
 pd_r <- ripserr::vietoris_rips(x, dim_max = 1)
 pd_3 <- unclass(pd_a$diagram)


### PR DESCRIPTION
In test-landscape-exact.R, line 31 was originally using `$add()` while it should be using `pl_sum()` based on the title of the `test_that()` on line 24.  After fixing the code, I confirmed that all 5 tests passed.